### PR TITLE
Post 일부 필드 DB 타입 선언, PostResponse 코드 리팩토링

### DIFF
--- a/src/main/java/com/bugflix/weblog/post/controller/PostController.java
+++ b/src/main/java/com/bugflix/weblog/post/controller/PostController.java
@@ -92,7 +92,7 @@ public class PostController {
     }
 
     /**
-     * Name : getPost
+     * Name : getAllPost
      * Parameter :
      * - String url: web page 주소
      * Return :

--- a/src/main/java/com/bugflix/weblog/post/domain/Post.java
+++ b/src/main/java/com/bugflix/weblog/post/domain/Post.java
@@ -30,7 +30,7 @@ public class Post extends BaseTimeEntity {
     @Column(columnDefinition = "LONGTEXT")
     private String memo;
 
-    @Column(name = "image_url")
+    @Column(name = "image_url", columnDefinition = "LONGTEXT")
     private String imageUrl;
 
     @ManyToOne

--- a/src/main/java/com/bugflix/weblog/post/domain/Post.java
+++ b/src/main/java/com/bugflix/weblog/post/domain/Post.java
@@ -23,8 +23,13 @@ public class Post extends BaseTimeEntity {
     private Long postId;
 
     private String title;
+
+    @Column(columnDefinition = "LONGTEXT")
     private String content;
+
+    @Column(columnDefinition = "LONGTEXT")
     private String memo;
+
     @Column(name = "image_url")
     private String imageUrl;
 

--- a/src/main/java/com/bugflix/weblog/post/dto/PostResponse.java
+++ b/src/main/java/com/bugflix/weblog/post/dto/PostResponse.java
@@ -3,13 +3,16 @@ package com.bugflix.weblog.post.dto;
 import com.bugflix.weblog.post.domain.Post;
 import com.bugflix.weblog.tag.dto.TagResponse;
 import com.bugflix.weblog.user.domain.User;
-import lombok.Data;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
-@Data
-@NoArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostResponse {
     private Long postId;
     private String title;
@@ -20,20 +23,54 @@ public class PostResponse {
     private boolean isLike;
     private String nickname;
     private String profileImageUrl;
+    private LocalDateTime createdDate;
+    private LocalDateTime updatedDate;
 
-    public PostResponse(Post post) {
-        title = post.getTitle();
-        content = post.getContent();
-        memo = post.getMemo();
-        postId = post.getPostId();
+    @Builder
+    private PostResponse(Long postId, String title, List<TagResponse> tags, String content, String memo, Long likeCount, boolean isLike, String nickname, String profileImageUrl, LocalDateTime createdDate, LocalDateTime updatedDate) {
+        this.postId = postId;
+        this.title = title;
+        this.tags = tags;
+        this.content = content;
+        this.memo = memo;
+        this.likeCount = likeCount;
+        this.isLike = isLike;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.createdDate = createdDate;
+        this.updatedDate = updatedDate;
     }
 
-    // Todo Profile 추가
-    public PostResponse(Post post, User user, List<TagResponse> tags) {
-        this(post);
-        this.tags = tags;
+    @Builder
+    private PostResponse(Long postId, String title, String content, String memo) {
+        this.postId = postId;
+        this.title = title;
+        this.content = content;
+        this.memo = memo;
+    }
 
-        nickname = user.getNickname();
-        // profileImageUrl = profile.getProfileImageUrl();
+    public static PostResponse of(Post post, User user, List<TagResponse> tags, Long likeCount, Boolean isLike) {
+        return PostResponse.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .tags(tags)
+                .content(post.getContent())
+                .memo(post.getMemo())
+                .likeCount(likeCount)
+                .isLike(isLike)
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfile().getImageUrl())
+                .createdDate(post.getCreatedDate())
+                .updatedDate(post.getModifiedDate())
+                .build();
+    }
+
+    public static PostResponse from(Post post) {
+        return PostResponse.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .memo(post.getMemo())
+                .build();
     }
 }

--- a/src/main/java/com/bugflix/weblog/post/dto/PostResponse.java
+++ b/src/main/java/com/bugflix/weblog/post/dto/PostResponse.java
@@ -26,7 +26,7 @@ public class PostResponse {
     private LocalDateTime createdDate;
     private LocalDateTime updatedDate;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private PostResponse(Long postId, String title, List<TagResponse> tags, String content, String memo, Long likeCount, boolean isLike, String nickname, String profileImageUrl, LocalDateTime createdDate, LocalDateTime updatedDate) {
         this.postId = postId;
         this.title = title;
@@ -41,7 +41,7 @@ public class PostResponse {
         this.updatedDate = updatedDate;
     }
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private PostResponse(Long postId, String title, String content, String memo) {
         this.postId = postId;
         this.title = title;

--- a/src/main/java/com/bugflix/weblog/post/repository/PostRepository.java
+++ b/src/main/java/com/bugflix/weblog/post/repository/PostRepository.java
@@ -7,8 +7,8 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    public List<Post> findByPageUrl(String url);
+    List<Post> findByPageUrl(String url);
 
-    public List<Post> findByPageUrlAndUserUserId(String url, Long userId);
+    List<Post> findByPageUrlAndUserUserId(String url, Long userId);
 
 }

--- a/src/main/java/com/bugflix/weblog/post/service/PostServiceImpl.java
+++ b/src/main/java/com/bugflix/weblog/post/service/PostServiceImpl.java
@@ -113,29 +113,17 @@ public class PostServiceImpl {
      */
     public PostResponse getPost(Long postId, UserDetails userDetails) throws Exception {
         Post post = postRepository.findById(postId).orElseThrow(() -> new Exception(""));
-        PostResponse postResponse = new PostResponse(post);
-
+        User user = post.getUser();
         Long userId = ((CustomUserDetails)userDetails).getUser().getUserId();
-        // Todo 1. post Update Logic 구성
-        postResponse.setNickname(userService.findNicknameByPostId(postId));
-        postResponse.setTags(tagService.findTagsByPostId(postId));
-        postResponse.setLike(likeServiceImpl.isLiked(postId, userId));
-        postResponse.setLikeCount(likeServiceImpl.countLikes(postId));
-
-        return postResponse;
+        return PostResponse.of(post, user, tagService.findTagsByPostId(postId),
+                likeServiceImpl.countLikes(postId), likeServiceImpl.isLiked(postId, userId));
     }
 
     public PostResponse getPost(Long postId) throws Exception {
         Post post = postRepository.findById(postId).orElseThrow(() -> new Exception(""));
-        PostResponse postResponse = new PostResponse(post);
-
-        // Todo 1. post Update Logic 구성
-        postResponse.setNickname(userService.findNicknameByPostId(postId));
-        postResponse.setTags(tagService.findTagsByPostId(postId));
-        postResponse.setLike(false);
-        postResponse.setLikeCount(likeServiceImpl.countLikes(postId));
-
-        return postResponse;
+        User user = post.getUser();
+        return PostResponse.of(post, user, tagService.findTagsByPostId(postId),
+                likeServiceImpl.countLikes(postId), false);
     }
 
     /**
@@ -152,11 +140,8 @@ public class PostServiceImpl {
     public List<PostResponse> getPosts(String url) {
 
         List<Post> resultList = postRepository.findByPageUrl(url);
-        List<PostResponse> resultArrayList = new ArrayList<>();
-
-        resultList.forEach(post -> resultArrayList.add(new PostResponse(post)));
         // Todo : Tag, LikeCount, Profile, nickname 등 추가 필요
-        return resultArrayList;
+        return resultList.stream().map(PostResponse::from).toList();
     }
 
     /**

--- a/src/main/java/com/bugflix/weblog/user/controller/UserController.java
+++ b/src/main/java/com/bugflix/weblog/user/controller/UserController.java
@@ -22,8 +22,6 @@ public class UserController {
     @Operation(summary = "회원가입", description = "신규 사용자 정보를 등록합니다.")
     @PostMapping("/v1/users")
     public ResponseEntity<Void> signUp(@RequestBody SignUpRequest signUpRequest) {
-//        @AuthenticationPrincipal CustomUserDetails customUserDetails,
-//        customUserDetails.getUser().getUserId();
         userService.register(signUpRequest);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/bugflix/weblog/user/service/UserServiceImpl.java
+++ b/src/main/java/com/bugflix/weblog/user/service/UserServiceImpl.java
@@ -49,10 +49,6 @@ public class UserServiceImpl {
         userRepository.delete(user);
     }
 
-    public void saveUser(User user) {
-        userRepository.save(user);
-    }
-
     public String findNicknameByPostId(Long postId) {
         User user = userRepository.findByPosts_PostId(postId);
         return user.getNickname();


### PR DESCRIPTION
## #️⃣연관된 이슈

close #16 
close #17 

## 📝작업 내용
- Post 엔티티 content / memo / imageUrl 필드가 MySQL에서 LONGTEXT로 저장되도록 변경했습니다.
- PostReposne 클래스의 @Data 어노테이션을 들어내고 연관된 서비스에서 생성자 대신 정적팩터리를 사용하도록 변경했습니다.
