### PR TITLE
대시보드, 주간/월간/연간 인기포스트 조회 기능

### DIFF
--- a/src/main/java/com/bugflix/weblog/post/controller/PostController.java
+++ b/src/main/java/com/bugflix/weblog/post/controller/PostController.java
@@ -1,5 +1,9 @@
 package com.bugflix.weblog.post.controller;
 
+import com.bugflix.weblog.post.dto.PostPopularRequest;
+import com.bugflix.weblog.post.dto.PostPreviewResponse;
+import com.bugflix.weblog.post.dto.PostRequest;
+import com.bugflix.weblog.post.dto.PostResponse;
 import com.bugflix.weblog.post.dto.*;
 import com.bugflix.weblog.post.service.PostServiceImpl;
 import lombok.RequiredArgsConstructor;
@@ -165,6 +169,11 @@ public class PostController {
 
         postServiceImpl.deletePost(postId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/v1/posts/ranks")
+    public ResponseEntity<List<PostPreviewResponse>> getPopularPosts(@ModelAttribute PostPopularRequest postPopularRequest) {
+        return ResponseEntity.ok(postServiceImpl.getPopularPosts(postPopularRequest));
     }
 
     @GetMapping("/v1/search/posts")

--- a/src/main/java/com/bugflix/weblog/post/domain/Period.java
+++ b/src/main/java/com/bugflix/weblog/post/domain/Period.java
@@ -1,0 +1,16 @@
+package com.bugflix.weblog.post.domain;
+
+import lombok.Getter;
+
+public enum Period {
+    WEEKLY(7),
+    MONTHLY(30),
+    YEARLY(365);
+
+    @Getter
+    private final Integer value;
+
+    Period(Integer value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/bugflix/weblog/post/domain/Post.java
+++ b/src/main/java/com/bugflix/weblog/post/domain/Post.java
@@ -44,6 +44,8 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Tag> tags = new ArrayList<>();
 
+    @Column(name = "like_count")
+    private Long likeCount = 0L;
 
     public Post(PostRequest postRequest) {
         title = postRequest.getTitle();
@@ -68,5 +70,13 @@ public class Post extends BaseTimeEntity {
 
     public void updateMemo(String memo) {
         this.memo = memo;
+    }
+
+    public void setLike() {
+        this.likeCount += 1;
+    }
+
+    public void setUnLike() {
+        this.likeCount -= 1;
     }
 }

--- a/src/main/java/com/bugflix/weblog/post/dto/PostPopularRequest.java
+++ b/src/main/java/com/bugflix/weblog/post/dto/PostPopularRequest.java
@@ -1,0 +1,13 @@
+package com.bugflix.weblog.post.dto;
+
+import com.bugflix.weblog.post.domain.Period;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostPopularRequest {
+    private Period type;
+    private Integer offset;
+    private Integer limit;
+}

--- a/src/main/java/com/bugflix/weblog/post/repository/PostRepository.java
+++ b/src/main/java/com/bugflix/weblog/post/repository/PostRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -12,6 +13,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByPageUrl(String url);
 
     List<Post> findByPageUrlAndUserUserId(String url, Long userId);
+
+    @Query("select p from post_tb p where p.modifiedDate > :criterion order by p.likeCount desc")
+    List<Post> findWithPagination(LocalDateTime criterion, Pageable pageable);
 
     @Query("select p from post_tb p " +
             "right join tag_tb t on t.post = p " +


### PR DESCRIPTION
## #️⃣연관된 이슈

close #22 

## 📝작업 내용

- 대시보드에 들어갈 인기포스트 조회 기능을 구현했습니다.
- 페이징 (offset - limit)
- 주간/월간/연간 세 종류의 검색 조건 지원

## 💬리뷰 요구사항

- Post 엔티티에 likeCount 필드가 추가되었습니다.
- Post 엔티티 수정으로 인해 PATCH /api/v1/likes/{postId} 엔드포인트의 로직이 수정되었습니다.
