### PR TITLE
Post 조회 API Response,tags 필드의 타입을 List<String>으로 개선

### DIFF
--- a/src/main/java/com/bugflix/weblog/post/dto/PostPreviewResponse.java
+++ b/src/main/java/com/bugflix/weblog/post/dto/PostPreviewResponse.java
@@ -1,7 +1,6 @@
 package com.bugflix.weblog.post.dto;
 
 import com.bugflix.weblog.post.domain.Post;
-import com.bugflix.weblog.tag.dto.TagResponse;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -12,7 +11,7 @@ public class PostPreviewResponse {
     private Long postId;
     private String title;
     private String nickname;
-    private List<TagResponse> tags;
+    private List<String> tags;
     private Long likeCount;
     private Boolean isLiked;
     private String imageUrl;
@@ -21,7 +20,7 @@ public class PostPreviewResponse {
 
     public PostPreviewResponse(
             Post post,
-            List<TagResponse> tags,
+            List<String> tags,
             String nickname,
             Boolean isLiked,
             LocalDateTime createdDate,

--- a/src/main/java/com/bugflix/weblog/post/dto/PostResponse.java
+++ b/src/main/java/com/bugflix/weblog/post/dto/PostResponse.java
@@ -1,7 +1,6 @@
 package com.bugflix.weblog.post.dto;
 
 import com.bugflix.weblog.post.domain.Post;
-import com.bugflix.weblog.tag.dto.TagResponse;
 import com.bugflix.weblog.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,7 +15,7 @@ import java.util.List;
 public class PostResponse {
     private Long postId;
     private String title;
-    private List<TagResponse> tags;
+    private List<String> tags;
     private String content;
     private String memo;
     private Long likeCount;
@@ -27,7 +26,7 @@ public class PostResponse {
     private LocalDateTime updatedDate;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private PostResponse(Long postId, String title, List<TagResponse> tags, String content, String memo, Long likeCount, boolean isLike, String nickname, String profileImageUrl, LocalDateTime createdDate, LocalDateTime updatedDate) {
+    private PostResponse(Long postId, String title, List<String> tags, String content, String memo, Long likeCount, boolean isLike, String nickname, String profileImageUrl, LocalDateTime createdDate, LocalDateTime updatedDate) {
         this.postId = postId;
         this.title = title;
         this.tags = tags;
@@ -49,7 +48,7 @@ public class PostResponse {
         this.memo = memo;
     }
 
-    public static PostResponse of(Post post, User user, List<TagResponse> tags, Long likeCount, Boolean isLike) {
+    public static PostResponse of(Post post, User user, List<String> tags, Long likeCount, Boolean isLike) {
         return PostResponse.builder()
                 .postId(post.getPostId())
                 .title(post.getTitle())

--- a/src/main/java/com/bugflix/weblog/post/service/PostServiceImpl.java
+++ b/src/main/java/com/bugflix/weblog/post/service/PostServiceImpl.java
@@ -10,7 +10,6 @@ import com.bugflix.weblog.post.dto.PostResponse;
 import com.bugflix.weblog.post.repository.PostRepository;
 import com.bugflix.weblog.security.domain.CustomUserDetails;
 import com.bugflix.weblog.tag.domain.Tag;
-import com.bugflix.weblog.tag.dto.TagResponse;
 import com.bugflix.weblog.tag.repository.TagRepository;
 import com.bugflix.weblog.tag.service.TagServiceImpl;
 import com.bugflix.weblog.user.domain.User;
@@ -31,7 +30,6 @@ public class PostServiceImpl {
     private final PostRepository postRepository;
     private final PageRepository pageRepository;
     private final LikeServiceImpl likeServiceImpl;
-    private final TagServiceImpl tagService;
     private final UserServiceImpl userService;
     private final TagRepository tagRepository;
 
@@ -115,14 +113,16 @@ public class PostServiceImpl {
         Post post = postRepository.findById(postId).orElseThrow(() -> new Exception(""));
         User user = post.getUser();
         Long userId = ((CustomUserDetails)userDetails).getUser().getUserId();
-        return PostResponse.of(post, user, tagService.findTagsByPostId(postId),
+        return PostResponse.of(post, user,
+                tagRepository.findTagsByPostPostId(postId).stream().map(Tag::getTagContent).toList(),
                 likeServiceImpl.countLikes(postId), likeServiceImpl.isLiked(postId, userId));
     }
 
     public PostResponse getPost(Long postId) throws Exception {
         Post post = postRepository.findById(postId).orElseThrow(() -> new Exception(""));
         User user = post.getUser();
-        return PostResponse.of(post, user, tagService.findTagsByPostId(postId),
+        return PostResponse.of(post, user,
+                tagRepository.findTagsByPostPostId(postId).stream().map(Tag::getTagContent).toList(),
                 likeServiceImpl.countLikes(postId), false);
     }
 
@@ -166,7 +166,7 @@ public class PostServiceImpl {
 
             PostPreviewResponse postPreview = new PostPreviewResponse(
                     post,
-                    tagRepository.findTagsByPostPostId(postId).stream().map(TagResponse::from).toList(),
+                    tagRepository.findTagsByPostPostId(postId).stream().map(Tag::getTagContent).toList(),
                     userService.findNicknameByPostId(postId),
                     likeServiceImpl.isLiked(postId, userId),
                     post.getCreatedDate(),
@@ -190,7 +190,7 @@ public class PostServiceImpl {
 
             PostPreviewResponse postPreview = new PostPreviewResponse(
                     post,
-                    tagRepository.findTagsByPostPostId(postId).stream().map(TagResponse::from).toList(),
+                    tagRepository.findTagsByPostPostId(postId).stream().map(Tag::getTagContent).toList(),
                     userService.findNicknameByPostId(postId),
                     false,
                     post.getCreatedDate(),
@@ -225,7 +225,7 @@ public class PostServiceImpl {
 
             PostPreviewResponse postPreview = new PostPreviewResponse(
                     post,
-                    tagRepository.findTagsByPostPostId(postId).stream().map(TagResponse::from).toList(),
+                    tagRepository.findTagsByPostPostId(postId).stream().map(Tag::getTagContent).toList(),
                     userService.findNicknameByPostId(postId),
                     likeServiceImpl.isLiked(postId, userId),
                     post.getCreatedDate(),


### PR DESCRIPTION
## #️⃣연관된 이슈

close #31 

## 📝작업 내용

- 기존, Post 조회 시 tags 필드가 List<TagResponse> 타입이었던 것을 List<String>으로 개선했습니다.
- TagResponse는 Tag 값을 나타내는 tagContent만을 갖습니다. API를 더 단순화하고 사용성을 높이기위해 변경했습니다.

### 스크린샷 (선택)

- before
![image](https://github.com/BugFlix/server/assets/121238128/4f35c648-3960-41b4-8467-c7510a3d06a2)

- after
![image](https://github.com/BugFlix/server/assets/121238128/e94e72b4-c1f0-41d6-bf25-61e05a311a06)


## 💬리뷰 요구사항(선택)

해당 변경사항으로 인해 클라이언트에서도 해당 API를 사용하고 있는 부분에 변경이 필요할 것으로 보입니다.
해당 부분 확인 부탁드립니다!
