### PR TITLE
포스트 검색 기능을 추가합니다

### DIFF
--- a/src/main/java/com/bugflix/weblog/config/SecurityConfiguration.java
+++ b/src/main/java/com/bugflix/weblog/config/SecurityConfiguration.java
@@ -8,10 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -65,6 +63,7 @@ public class SecurityConfiguration {
                 .authorizeHttpRequests(authorize -> {
                     authorize
                             .requestMatchers(HttpMethod.POST, "/api/v1/posts").hasRole("USER")
+                            .requestMatchers(HttpMethod.GET, "/api/v1/search/posts").hasRole("USER")
                             .requestMatchers(HttpMethod.PUT, "/api/v1/posts").hasRole("USER")
                             .requestMatchers(HttpMethod.GET, "/api/v1/posts/mine").hasRole("USER")
                             .requestMatchers(HttpMethod.DELETE, "/api/v1/posts/**").hasRole("USER")

--- a/src/main/java/com/bugflix/weblog/post/controller/PostController.java
+++ b/src/main/java/com/bugflix/weblog/post/controller/PostController.java
@@ -1,8 +1,6 @@
 package com.bugflix.weblog.post.controller;
 
-import com.bugflix.weblog.post.dto.PostPreviewResponse;
-import com.bugflix.weblog.post.dto.PostRequest;
-import com.bugflix.weblog.post.dto.PostResponse;
+import com.bugflix.weblog.post.dto.*;
 import com.bugflix.weblog.post.service.PostServiceImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -169,4 +167,8 @@ public class PostController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/v1/search/posts")
+    public ResponseEntity<List<PostSearchResponse>> searchPost(@ModelAttribute PostSearchRequest postSearchRequest) {
+        return ResponseEntity.ok(postServiceImpl.searchPost(postSearchRequest));
+    }
 }

--- a/src/main/java/com/bugflix/weblog/post/domain/SearchType.java
+++ b/src/main/java/com/bugflix/weblog/post/domain/SearchType.java
@@ -1,0 +1,7 @@
+package com.bugflix.weblog.post.domain;
+
+public enum SearchType {
+    TAG,
+    CONTENT,
+    TAG_AND_CONTENT;
+}

--- a/src/main/java/com/bugflix/weblog/post/dto/PostSearchRequest.java
+++ b/src/main/java/com/bugflix/weblog/post/dto/PostSearchRequest.java
@@ -1,0 +1,19 @@
+package com.bugflix.weblog.post.dto;
+
+import com.bugflix.weblog.post.domain.SearchType;
+import lombok.Getter;
+
+@Getter
+public class PostSearchRequest {
+    private String query;
+    private SearchType type;
+    private Integer offset;
+    private Integer limit;
+
+    private PostSearchRequest(String query, SearchType type, Integer offset, Integer limit) {
+        this.query = query;
+        this.type = type;
+        this.offset = offset;
+        this.limit = limit;
+    }
+}

--- a/src/main/java/com/bugflix/weblog/post/dto/PostSearchResponse.java
+++ b/src/main/java/com/bugflix/weblog/post/dto/PostSearchResponse.java
@@ -1,0 +1,34 @@
+package com.bugflix.weblog.post.dto;
+
+
+import com.bugflix.weblog.post.domain.Post;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PostSearchResponse {
+    private Long postId;
+    private String title;
+    private String nickname;
+    private List<String> tags;
+
+    @Builder(access = AccessLevel.PROTECTED)
+    private PostSearchResponse(Long postId, String title, String nickname, List<String> tags) {
+        this.postId = postId;
+        this.title = title;
+        this.nickname = nickname;
+        this.tags = tags;
+    }
+
+    public static PostSearchResponse of(Post e, String nickname, List<String> tags) {
+        return PostSearchResponse.builder()
+                .postId(e.getPostId())
+                .title(e.getTitle())
+                .nickname(nickname)
+                .tags(tags)
+                .build();
+    }
+}

--- a/src/main/java/com/bugflix/weblog/post/repository/PostRepository.java
+++ b/src/main/java/com/bugflix/weblog/post/repository/PostRepository.java
@@ -1,7 +1,9 @@
 package com.bugflix.weblog.post.repository;
 
 import com.bugflix.weblog.post.domain.Post;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -11,4 +13,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByPageUrlAndUserUserId(String url, Long userId);
 
+    @Query("select p from post_tb p " +
+            "right join tag_tb t on t.post = p " +
+            "join user_tb u on p.user = u " +
+            "where t.tagContent = :query")
+    List<Post> findPostsByTagContent(String query, Pageable pageable);
+
+    @Query("select p from post_tb p join fetch p.tags join fetch p.user where p.title like %:query%")
+    List<Post> findPostsByTitleLike(String query, Pageable pageable);
 }

--- a/src/main/java/com/bugflix/weblog/tag/domain/Tag.java
+++ b/src/main/java/com/bugflix/weblog/tag/domain/Tag.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity(name = "tag_tb")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Tag extends BaseTimeEntity {
@@ -16,7 +17,7 @@ public class Tag extends BaseTimeEntity {
     @Column(name = "tag_id")
     private Long tagId;
 
-    @Getter
+    @Column(name = "tag_content")
     private String tagContent;
 
     @ManyToOne

--- a/src/main/java/com/bugflix/weblog/tag/repository/TagRepository.java
+++ b/src/main/java/com/bugflix/weblog/tag/repository/TagRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
-
     List<Tag> findTagsByPostPostId(Long postId);
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
close #27 

## 📝작업 내용

포스트 검색 기능, 3가지 조건을 선택하여 검색합니다
- TAG (완전일치)
- CONTENT (제목에 해당하는 query 문자열이 포함되어 있는 경우)
- TAG_AND_CONTENT (위 두 가지 중 하나라도 포함된 경우)


## 💬리뷰 요구사항(선택)
현재 TAG_AND_CONTENT 로직이 우선 limit 수량에는 맞췄지만, 자연스레 로직 상 우선순위가 발생합니다.
개선할 수 있는 방법이 있을까요?