### PR TITLE
서버에 HTTPS 프로토콜 적용

### DIFF
--- a/src/main/java/com/bugflix/weblog/common/healthcheck/HealthCheckController.java
+++ b/src/main/java/com/bugflix/weblog/common/healthcheck/HealthCheckController.java
@@ -1,0 +1,16 @@
+package com.bugflix.weblog.common.healthcheck;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/api/v1/healthcheck")
+    public ResponseEntity<Void> healthcheck() {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/bugflix/weblog/config/SecurityConfiguration.java
+++ b/src/main/java/com/bugflix/weblog/config/SecurityConfiguration.java
@@ -45,7 +45,8 @@ public class SecurityConfiguration {
     private static final String[] PERMIT_TO_ALL = {
             "/api/v1/users",
             "/api/v1/auths/login",
-            "/api/v1/auths/reissue"
+            "/api/v1/auths/reissue",
+            "/api/v1/healthcheck"
     };
 
     @Bean


### PR DESCRIPTION
## #️⃣연관된 이슈
close #35 

## 📝작업 내용
* ELB 헬스체크용 API 작성
* scrabler.com 도메인 구입 및 route 53 등록
* ACM 인증서, ALB를 사용한 HTTPS 통신 허용
