### PR TITLE
fix: swagger 페이지 API 요청 시, CORS 문제 해결

### DIFF
--- a/src/main/java/com/bugflix/weblog/WeblogApplication.java
+++ b/src/main/java/com/bugflix/weblog/WeblogApplication.java
@@ -1,9 +1,12 @@
 package com.bugflix.weblog;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@OpenAPIDefinition(servers = {@Server(url = "/", description = "Default Server url")})
 @EnableJpaAuditing
 @SpringBootApplication
 public class WeblogApplication {


### PR DESCRIPTION
## #️⃣연관된 이슈
close #42 

## 📝작업 내용
<img width="763" alt="스크린샷 2024-03-07 오후 1 11 10" src="https://github.com/BugFlix/server/assets/121238128/f73bf7b4-11a2-4353-8f15-0f850499749a">

* OpenApiDefinition 어노테이션으로 deafult 서버 URL을 '/'로 수정.
* 이제 Swagger 페이지에서 서버 URL을 기본으로 요청을 보냅니다.

### 스크린샷 (선택)
<img width="671" alt="스크린샷 2024-03-07 오후 1 10 42" src="https://github.com/BugFlix/server/assets/121238128/5c9615d2-0e9c-4606-a1a5-78c4a22aee33">
<img width="215" alt="스크린샷 2024-03-07 오후 1 10 53" src="https://github.com/BugFlix/server/assets/121238128/e90656e4-3a73-406a-a398-ff09838f642c">
