### PR TITLE
사용자 Profile 조회 컨트롤러의 UserDetails가 요청 파라미터로 설정되어있습니다. 

### DIFF
--- a/src/main/java/com/bugflix/weblog/post/service/PostServiceImpl.java
+++ b/src/main/java/com/bugflix/weblog/post/service/PostServiceImpl.java
@@ -13,6 +13,7 @@ import com.bugflix.weblog.post.repository.PostRepository;
 import com.bugflix.weblog.security.domain.CustomUserDetails;
 import com.bugflix.weblog.tag.domain.Tag;
 import com.bugflix.weblog.tag.repository.TagRepository;
+import com.bugflix.weblog.tag.service.TagServiceImpl;
 import com.bugflix.weblog.user.domain.User;
 import com.bugflix.weblog.user.service.UserServiceImpl;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/bugflix/weblog/profile/controller/ProfileController.java
+++ b/src/main/java/com/bugflix/weblog/profile/controller/ProfileController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +23,7 @@ public class ProfileController {
 
     @GetMapping("/v1/profiles/mine")
     @Operation(summary = "Profile 조회", description = "사용자 본인 Profile을 조회합니다.")
-    public ResponseEntity<ProfileResponse> getMyProfile(UserDetails userDetails) throws Exception {
+    public ResponseEntity<ProfileResponse> getMyProfile(@AuthenticationPrincipal UserDetails userDetails) throws Exception {
 
         return ResponseEntity.ok(profileService.getMyProfile(userDetails));
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
close #46 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
기존 Request의 파라미터로 받던 UserDetails를 JWT 토큰 및 SecurityContext를 이용하도록 @AuthenticationPrincipal 어노테이션을 추가했습니다.

### 스크린샷 (선택)
<img width="869" alt="스크린샷 2024-03-07 오후 4 37 01" src="https://github.com/BugFlix/server/assets/121238128/4d684ad5-370b-4455-9a59-2603a28c2e48">
