### PR TITLE
ProfileResponse 생성자에서 imageUrl의 null 검사를 올바르게 수정했습니다.

### DIFF
--- a/src/main/java/com/bugflix/weblog/profile/dto/ProfileResponse.java
+++ b/src/main/java/com/bugflix/weblog/profile/dto/ProfileResponse.java
@@ -14,8 +14,7 @@ public class ProfileResponse {
         nickname = user.getNickname();
         email = user.getEmail();
 
-        // imageURL null check
-        if (!(profile.getImageUrl().isEmpty())) {
+        if (profile.getImageUrl() != null) {
             this.imageUrl = profile.getImageUrl();
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #54 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

null 체크 로직 수정

