### PR TITLE
Comment 대댓글 작성 시 댓글로 저장되는 문제 해결

### DIFF
--- a/src/main/java/com/bugflix/weblog/comment/dto/CommentRequest.java
+++ b/src/main/java/com/bugflix/weblog/comment/dto/CommentRequest.java
@@ -15,7 +15,6 @@ import lombok.Setter;
 public class CommentRequest {
     @NotBlank(message = "not allow blank comment")
     private String content;
-    @Null
     private Long parentCommentId;
     @NotNull
     private Long postId;

--- a/src/main/java/com/bugflix/weblog/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/bugflix/weblog/comment/service/CommentServiceImpl.java
@@ -43,11 +43,11 @@ public class CommentServiceImpl {
         // 3. Comment 객체 생성
         Comment comment;
         if (commentRequest.getParentCommentId() != null) {
-            comment = Comment.of(commentRequest.getContent(), user, post);
-        } else {
             Comment parentComment = commentRepository.findById(commentRequest.getParentCommentId())
                     .orElseThrow(() -> new IllegalArgumentException("parentComment를 찾을 수 없습니다."));
-            comment = Comment.of(commentRequest.getContent(), user, post,parentComment);
+            comment = Comment.of(commentRequest.getContent(), user, post, parentComment);
+        } else {
+            comment = Comment.of(commentRequest.getContent(), user, post);
         }
 
         // 4. Comment 저장


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #56 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

parentCommentId의  null 검사로 나뉘는 분기가 반대로 작성된 것을 고쳤습니다.