### PR TITLE
대시보드에서 마이포스트 조회가 계속 실패합니다.

### DIFF
--- a/src/main/java/com/bugflix/weblog/post/controller/PostController.java
+++ b/src/main/java/com/bugflix/weblog/post/controller/PostController.java
@@ -163,7 +163,7 @@ public class PostController {
                                                                       @AuthenticationPrincipal UserDetails userDetails) {
         List<PostPreviewResponse> postPreviewResponses;
 
-        if (url.isEmpty()) postPreviewResponses = postServiceImpl.getMyPostPreview(userDetails);
+        if (url == null) postPreviewResponses = postServiceImpl.getMyPostPreview(userDetails);
         else postPreviewResponses = postServiceImpl.getMyPostPreview(url,userDetails);
 
         return ResponseEntity.ok(postPreviewResponses);


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #59 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

url.isEmpty()는 빈 문자열을 검사. null 검사를 수행하지 못함 