### PR TITLE
댓글 삭제, 수정 중 사용자 확인이 항상 실패하는 버그

### DIFF
--- a/src/main/java/com/bugflix/weblog/comment/domain/Comment.java
+++ b/src/main/java/com/bugflix/weblog/comment/domain/Comment.java
@@ -34,7 +34,7 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "parent_comment_id")
     private Comment parentComment;
 
-    @OneToMany(mappedBy = "parentComment")
+    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL)
     private List<Comment> childrenComment = new ArrayList<>();
 
     private Comment(String content, User user, Post post) {

--- a/src/main/java/com/bugflix/weblog/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/bugflix/weblog/comment/service/CommentServiceImpl.java
@@ -70,9 +70,10 @@ public class CommentServiceImpl {
          todo: 2.Transactional 어노테이션을 사용하지 않아도 comment.getUser()가 가능한가?
           => ManyToOne 연관관계로 기본 Fetch 전략이 EAGER
          */
-        if (comment.getUser() == user) {
+        if (comment.getUser().getUserId() == user.getUserId()) {
             // 3. Comment 의 내용 update
             comment.updateContent(content);
+            commentRepository.save(comment);
         } else {
             throw new IllegalArgumentException("Only writer can update");
         }
@@ -87,7 +88,7 @@ public class CommentServiceImpl {
                 .orElseThrow(() -> new IllegalArgumentException("invalid commentId"));
 
         // 3. user 정보와 comment 의 소유자가 동일한지 확인
-        if (comment.getUser() == user) {
+        if (comment.getUser().getUserId() == user.getUserId()) {
             commentRepository.delete(comment);
         } else {
             throw new IllegalArgumentException("Only writer can delete");


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #62 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

엔티티 간 동등비교 연산을, 엔티티 식별자 간 비교 연산으로 수정하였습니다.
