### PR TITLE
댓글 작성 시, Post가 삭제되지 않던 오류

### DIFF
--- a/src/main/java/com/bugflix/weblog/comment/domain/Comment.java
+++ b/src/main/java/com/bugflix/weblog/comment/domain/Comment.java
@@ -34,7 +34,7 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "parent_comment_id")
     private Comment parentComment;
 
-    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "parentComment", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Comment> childrenComment = new ArrayList<>();
 
     private Comment(String content, User user, Post post) {

--- a/src/main/java/com/bugflix/weblog/page/domain/Page.java
+++ b/src/main/java/com/bugflix/weblog/page/domain/Page.java
@@ -21,7 +21,7 @@ public class Page {
     @Getter
     private String url;
 
-    @OneToMany(mappedBy = "page")
+    @OneToMany(mappedBy = "page", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Post> posts = new ArrayList<>();
 
     public Page(String url) {

--- a/src/main/java/com/bugflix/weblog/post/domain/Post.java
+++ b/src/main/java/com/bugflix/weblog/post/domain/Post.java
@@ -1,5 +1,6 @@
 package com.bugflix.weblog.post.domain;
 
+import com.bugflix.weblog.comment.domain.Comment;
 import com.bugflix.weblog.common.BaseTimeEntity;
 import com.bugflix.weblog.post.dto.PostRequest;
 import com.bugflix.weblog.tag.domain.Tag;
@@ -41,8 +42,11 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "page_id", nullable = false)
     private Page page;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Tag> tags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();
 
     @Column(name = "like_count")
     private Long likeCount = 0L;

--- a/src/main/java/com/bugflix/weblog/user/domain/User.java
+++ b/src/main/java/com/bugflix/weblog/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.bugflix.weblog.user.domain;
 
+import com.bugflix.weblog.comment.domain.Comment;
 import com.bugflix.weblog.common.BaseTimeEntity;
 import com.bugflix.weblog.post.domain.Post;
 import com.bugflix.weblog.profile.domain.Profile;
@@ -38,7 +39,10 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Authority> roles = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Post> posts = new ArrayList<>();
 
     @Builder


### PR DESCRIPTION
## #️⃣연관된 이슈

close #65 

## 📝작업 내용

포스트에 댓글이 달리면 포스트를 삭제할 수 없는 버그가 존재했습니다.
원인은 엔티티 간의 연관관계 설정이 잘못되어 있었습니다.
엔티티 간 연관관계 설정을 다시 잡아주었으며, 외래키를 참조하는 경우 CascadeType.ALL로 지정하였습니ㅏㄷ.