### PR TITLE
Post 저장 시 이미지 URL 대신 원본 글의 링크가 저장되는 버그

### DIFF
--- a/src/main/java/com/bugflix/weblog/post/domain/Post.java
+++ b/src/main/java/com/bugflix/weblog/post/domain/Post.java
@@ -55,7 +55,7 @@ public class Post extends BaseTimeEntity {
         title = postRequest.getTitle();
         content = postRequest.getContent();
         memo = postRequest.getMemo();
-        imageUrl = postRequest.getUrl();
+        imageUrl = postRequest.getImageUrl();
     }
 
     public Post(PostRequest postRequest, User user, Page page) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #67 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

포스트 저장 로직에 IMAGE_URL을 가져오는 부분이 URL로 되어있던 부분을 수정

